### PR TITLE
changing services for hub from NodePort to ClusterIP,

### DIFF
--- a/kubeapps-hub-values.yaml
+++ b/kubeapps-hub-values.yaml
@@ -16,7 +16,7 @@ api:
       clientSecret:
   service:
     name: monocular-api
-    type: NodePort
+    type: ClusterIP
     externalPort: 80
     internalPort: 8081
   resources:
@@ -61,7 +61,7 @@ ui:
     pullPolicy: Always
   service:
     name: monocular-ui
-    type: NodePort
+    type: ClusterIP
     externalPort: 80
     internalPort: 8080
   resources:
@@ -88,7 +88,7 @@ prerender:
   cacheEnabled: true
   service:
     name: prerender
-    type: NodePort
+    type: ClusterIP
     externalPort: 80
     internalPort: 3000
   resources:


### PR DESCRIPTION
this is a tidy up.

Since Hub requires an ingress to work properly then exposing the individual services lead to problems is accessing them directly, in some environments, it could be a problem