### PR TITLE
do not expose ingress controller to public

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,9 @@ script:
   - >-
     kubecfg validate -v kubeapps.jsonnet || :
   - ./kubeapps.sh up
-  - ./tests.sh $(./kubeapps.sh dashboard --url)
+  # We can't port-forward in Travis, so instead we patch the service type to node port
+  - kubectl patch -n kube-system svc nginx-ingress -p '{"spec":{"type":"NodePort"}}' && sleep 5
+  - ./tests.sh $(minikube service --namespace kube-system nginx-ingress --url)
 
 after_success:
   - kubectl get all --all-namespaces

--- a/ingress-nginx.jsonnet
+++ b/ingress-nginx.jsonnet
@@ -142,7 +142,7 @@ local kube = import "kube.libsonnet";
         {name: "http", port: 80, protocol: "TCP"},
         {name: "https", port: 443, protocol: "TCP"},
       ],
-      type: "LoadBalancer",
+      type: "ClusterIP",
     },
   },
 

--- a/kubeapps-dashboard.jsonnet
+++ b/kubeapps-dashboard.jsonnet
@@ -112,9 +112,6 @@ local serviceDeployFromValues(parentName, componentName, values) = {
               default+: {
                 env_+: {
                   MONOCULAR_HOME: "/monocular",
-                  MONOCULAR_AUTH_SIGNING_KEY: $.values.api.auth.signingKey,
-                  MONOCULAR_AUTH_GITHUB_CLIENT_ID: $.values.api.auth.github.clientID,
-                  MONOCULAR_AUTH_GITHUB_CLIENT_SECRET: $.values.api.auth.github.clientSecret,
                 },
                 livenessProbe: {
                   httpGet: {

--- a/kubeapps.sh
+++ b/kubeapps.sh
@@ -46,8 +46,9 @@ case "$subcommand" in
         exec kubecfg show kubeapps.jsonnet "$@"
         ;;
     dashboard)
-        echo "NB until front page is updated: kubeless-ui is at /kubeless" >&2
-        exec minikube service -n kube-system nginx-ingress "$@"
+        podname=$(kubectl get pods --namespace kube-system -l name=nginx-ingress-controller -o jsonpath="{.items[0].metadata.name}")
+        echo "Visit http://localhost:8002 in your browser"
+        exec kubectl port-forward --namespace kube-system "$podname" 8002:80
         ;;
     *)
         echo "Unknown subcommand: $subcommand" >&2


### PR DESCRIPTION
Sets the ingress controller service type as ClusterIP. The Dashboard
will be accessible via port-forwarding to the ingress controller pod
(see kubeapps/installer#41).

We also disable auth in the Monocular API server for now, in the future
we can make this configurable.