### PR TITLE
isolate nginx-ingress deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ script:
     kubecfg validate -v kubeapps.jsonnet || :
   - ./kubeapps.sh up
   # We can't port-forward in Travis, so instead we patch the service type to node port
-  - kubectl patch -n kube-system svc nginx-ingress -p '{"spec":{"type":"NodePort"}}' && sleep 5
-  - ./tests.sh $(minikube service --namespace kube-system nginx-ingress --url)
+  - kubectl patch -n kubeapps svc nginx-ingress -p '{"spec":{"type":"NodePort"}}' && sleep 5
+  - ./tests.sh $(minikube service --namespace kubeapps nginx-ingress --url)
 
 after_success:
   - kubectl get all --all-namespaces

--- a/kubeapps.jsonnet
+++ b/kubeapps.jsonnet
@@ -18,6 +18,22 @@ local tls = false;
   },
   ssecrets: (import "sealed-secrets.jsonnet"),
   nginx: (import "ingress-nginx.jsonnet") {
+    namespace:: $.namespace,
+    controller+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers_+: {
+              default+: {
+                args_+: {
+                  "ingress-class": "kubeapps-nginx",
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     service+: {
       spec+: {
         local maybe_https = if tls then [
@@ -80,7 +96,7 @@ local tls = false;
     metadata+: {
       annotations+: {
         "ingress.kubernetes.io/rewrite-target": "/",
-        "kubernetes.io/ingress.class": "nginx",
+        "kubernetes.io/ingress.class": "kubeapps-nginx",
         "ingress.kubernetes.io/ssl-redirect": std.toString(tls),
       },
     },

--- a/kubeapps.sh
+++ b/kubeapps.sh
@@ -32,7 +32,7 @@ case "$subcommand" in
         kubectl rollout status -n kubeapps deployment/kubeapps-dashboard-ui
         # FIXME: We don't wait for the API to rollout as it times out
         # kubectl rollout status -n kubeapps deployment/kubeapps-dashboard-api
-        kubectl rollout status -n kube-system deployment/nginx-ingress-controller
+        kubectl rollout status -n kubeapps deployment/nginx-ingress-controller
         ;;
     down)
         # This assumes kubeapps.jsonnet is in sync with what's
@@ -46,9 +46,9 @@ case "$subcommand" in
         exec kubecfg show kubeapps.jsonnet "$@"
         ;;
     dashboard)
-        podname=$(kubectl get pods --namespace kube-system -l name=nginx-ingress-controller -o jsonpath="{.items[0].metadata.name}")
+        podname=$(kubectl get pods --namespace kubeapps -l name=nginx-ingress-controller -o jsonpath="{.items[0].metadata.name}")
         echo "Visit http://localhost:8002 in your browser"
-        exec kubectl port-forward --namespace kube-system "$podname" 8002:80
+        exec kubectl port-forward --namespace kubeapps "$podname" 8002:80
         ;;
     *)
         echo "Unknown subcommand: $subcommand" >&2


### PR DESCRIPTION
- moves nginx-ingress to kubeapps namespace
- uses a custom ingress class 'kubeapps-ingress'

The idea here is to not interfere with any other Ingress Controllers
installed in the cluster (typically installed in the kube-system
namespace).