### PR TITLE
remove monocular api resource limits and tweak mem request

### DIFF
--- a/kubeapps-dashboard-values.yaml
+++ b/kubeapps-dashboard-values.yaml
@@ -20,12 +20,9 @@ api:
     externalPort: 80
     internalPort: 8081
   resources:
-    limits:
-      cpu: 100m
-      memory: 128Mi
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 512Mi
   livenessProbe:
     initialDelaySeconds: 180
   config:


### PR DESCRIPTION
This will stop OOMKilled stopping Monocular from syncing and I also bumped the memory request to 512Mi just to be on the safe side.