### PR TITLE
reduce chart refresh interval to 15 mins

### DIFF
--- a/kubeapps-dashboard-values.yaml
+++ b/kubeapps-dashboard-values.yaml
@@ -49,7 +49,7 @@ api:
     # Enable Helm deployment integration
     releasesEnabled: true
     # Cache refresh interval in sec.
-    cacheRefreshInterval: 3600
+    cacheRefreshInterval: 900
 ui:
   replicaCount: 1
   image:


### PR DESCRIPTION
Currently, adding a new repository in the Dashboard it can take up to an hour to see charts from the new repo to appear. This reduces that time greatly by configuring Monocular to sync every 15 mins.